### PR TITLE
Update-readme link from fork to source

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## 🔭 Current Projects
 
-### [🐙 fictional-octo-system](https://github.com/yves-steve/fictional-octo-system)
+### [🐙 fictional-octo-system](https://github.com/KuduWorks/fictional-octo-system)
 A work-in-progress multi-cloud Infrastructure as Code repository featuring:
 - 🌩️ Multi-cloud infrastructure automation (Azure, AWS, GCP) with Terraform
 - 🔒 Security compliance and policy management across clouds


### PR DESCRIPTION
This pull request updates the project link in the `README.md` file to point to the correct GitHub repository. This is a minor documentation fix to ensure users are directed to the right location.

- Updated the `fictional-octo-system` project link in `README.md` to use the `KuduWorks` organization instead of `yves-steve`.